### PR TITLE
Remove publisher and adjust homepage to fix Java publishing

### DIFF
--- a/provider/cmd/pulumi-resource-ise/schema.json
+++ b/provider/cmd/pulumi-resource-ise/schema.json
@@ -7,12 +7,11 @@
         "ise",
         "category/network"
     ],
-    "homepage": "https://github.com/pulumi/pulumi-ise",
+    "homepage": "https://pulumi.com",
     "license": "Apache-2.0",
     "attribution": "This Pulumi package is based on the [`ise` Terraform Provider](https://github.com/CiscoDevNet/terraform-provider-ise).",
     "repository": "https://github.com/pulumi/pulumi-ise",
     "logoUrl": "https://raw.githubusercontent.com/pulumi/pulumi-ise/main/docs/ise.png",
-    "publisher": "pulumi",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -143,11 +143,6 @@ func Provider() tfbridge.ProviderInfo {
 		// DisplayName is a way to be able to change the casing of the provider
 		// name when being displayed on the Pulumi registry
 		DisplayName: "Cisco ISE",
-		// The default publisher for all packages is Pulumi.
-		// Change this to your personal name (or a company name) that you
-		// would like to be shown in the Pulumi Registry if this package is published
-		// there.
-		Publisher: "pulumi",
 		// LogoURL is optional but useful to help identify your package in the Pulumi Registry
 		// if this package is published there.
 		//
@@ -164,7 +159,7 @@ func Provider() tfbridge.ProviderInfo {
 			"category/network",
 		},
 		License:    "Apache-2.0",
-		Homepage:   "https://github.com/pulumi/pulumi-ise",
+		Homepage:   "https://pulumi.com",
 		Repository: "https://github.com/pulumi/pulumi-ise",
 		// The GitHub Org for the provider - defaults to `terraform-providers`. Note that this
 		// should match the TF provider module's require directive, not any replace directives.

--- a/sdk/dotnet/Pulumi.Ise.csproj
+++ b/sdk/dotnet/Pulumi.Ise.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>pulumi</Authors>
-    <Company>pulumi</Company>
+    <Authors>Pulumi Corp.</Authors>
+    <Company>Pulumi Corp.</Company>
     <Description>A Pulumi package for managing resources on a Cisco ISE (Identity Service Engine) instance.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pulumi/pulumi-ise</PackageProjectUrl>
+    <PackageProjectUrl>https://pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-ise</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
     <Version>0.0.0-alpha.0+dev</Version>

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -89,8 +89,8 @@ publishing {
             artifact javadocJar
 
             pom {
-                inceptionYear = ""
-                name = ""
+                inceptionYear = "2022"
+                name = "pulumi-ise"
                 packaging = "jar"
                 description = "A Pulumi package for managing resources on a Cisco ISE (Identity Service Engine) instance."
 
@@ -111,9 +111,9 @@ publishing {
 
                 developers {
                     developer {
-                        id = ""
-                        name = ""
-                        email = ""
+                        id = "pulumi"
+                        name = "Pulumi"
+                        email = "support@pulumi.com"
                     }
                 }
             }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -7,7 +7,7 @@
         "ise",
         "category/network"
     ],
-    "homepage": "https://github.com/pulumi/pulumi-ise",
+    "homepage": "https://pulumi.com",
     "repository": "https://github.com/pulumi/pulumi-ise",
     "license": "Apache-2.0",
     "scripts": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -9,7 +9,7 @@
   [project.license]
     text = "Apache-2.0"
   [project.urls]
-    Homepage = "https://github.com/pulumi/pulumi-ise"
+    Homepage = "https://pulumi.com"
     Repository = "https://github.com/pulumi/pulumi-ise"
 
 [build-system]


### PR DESCRIPTION
Same as https://github.com/pulumi/pulumi-dbtcloud/pull/23

Right now, the Java publishing step fails because POM values aren't set correctly. We need to set the publisher and/or home page to expected values. This PR removes the non-canonical publisher (could have been Pulumi) and set the canonical homepage.