### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -224,6 +224,7 @@ func Provider() tfbridge.ProviderInfo {
 		Java: &tfbridge.JavaInfo{
 			BasePackage: "com.pulumi",
 		},
+		EnableAccurateBridgePreview: true,
 	}
 
 	prov.MustComputeTokens(moduleComputeStrategy())


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the provider.

part of pulumi/pulumi-terraform-bridge#2598